### PR TITLE
Hierarchical feed

### DIFF
--- a/Henbun/param.py
+++ b/Henbun/param.py
@@ -512,8 +512,9 @@ class Parameterized(Parentable):
         """
         Feed tensor x into all the child LocalVariable
         """
-        # --- assertion ---
-        assert len(self.get_variables(graph_key.LOCAL))>0
+        # --- skip if this object does not have LOCAL parameters ---
+        if len(self.get_variables(graph_key.LOCAL))==0:
+            return
         n_layers=self.get_variables(graph_key.LOCAL)[0].n_layers
         for p in self.get_variables(graph_key.LOCAL):
             assert len(p.n_layers) == len(n_layers)
@@ -523,7 +524,7 @@ class Parameterized(Parentable):
         # offset
         begin = np.zeros(len(n_layers) + 2)
         size = -np.ones(len(n_layers) + 2)
-        for p in self.get_variables(graph_key.LOCAL):
+        for p in self.sorted_variables:
             size[-2] = p.feed_size
             p.feed(tf.slice(x, tf.convert_to_tensor(begin, dtype=tf.int32),
                                tf.convert_to_tensor(size,  dtype=tf.int32)))

--- a/testing/test_variationals.py
+++ b/testing/test_variationals.py
@@ -64,6 +64,14 @@ class test_variational(unittest.TestCase):
         for shape in self.shapes:
             self.m[shape].initialize()
 
+    def test_get_variables(self):
+        """ Test get_variables certainly works even if in tf_mode """
+        for shape in self.shapes:
+            with self.m[shape].tf_mode():
+                variables = self.m[shape].get_variables()
+            self.assertTrue(self.m[shape].m.q_mu in variables)
+            self.assertTrue(self.m[shape].m.q_sqrt in variables)
+
     def test_parent(self):
         """ make sure its parent is model """
         for shape in self.shapes:
@@ -155,6 +163,14 @@ class test_variational_local(unittest.TestCase):
             self.m[shape].initialize()
         # immitate _draw_samples
         self.samples_iid = self.rng.randn(3,10,2).astype(np_float_type)
+
+    def test_get_variables(self):
+        """ Test get_variables certainly works even if in tf_mode """
+        for shape in self.shapes:
+            with self.m[shape].tf_mode():
+                variables = self.m[shape].get_variables(hb.param.graph_key.LOCAL)
+            self.assertTrue(self.m[shape].m.q_mu in variables)
+            self.assertTrue(self.m[shape].m.q_sqrt in variables)
 
     def test_logdet(self):
         # true solution

--- a/testing/test_variationals.py
+++ b/testing/test_variationals.py
@@ -169,8 +169,15 @@ class test_variational_local(unittest.TestCase):
         for shape in self.shapes:
             with self.m[shape].tf_mode():
                 variables = self.m[shape].get_variables(hb.param.graph_key.LOCAL)
+                feed_size = self.m[shape].feed_size
+                # test feed certainly works
+                self.m[shape].feed(self.rng.randn(3, feed_size, 100).astype(np_float_type))
+            # check feed_size is the same in tf_mode
+            self.assertTrue(feed_size == self.m[shape].feed_size)
             self.assertTrue(self.m[shape].m.q_mu in variables)
             self.assertTrue(self.m[shape].m.q_sqrt in variables)
+            # check certainly variational.feed works
+            self.assertTrue(hasattr(self.m[shape].m, '_tensor'))
 
     def test_logdet(self):
         # true solution


### PR DESCRIPTION
Bug fix.

In the previous implementation, feed() method is executed only in the highest parent object.
In the current implementation, feed() is executed recursively.